### PR TITLE
chore: [PAGOPA-3211] disable cron to retrieve fdr for gpd reporting

### DIFF
--- a/.github/workflows/gpd_get_fdr.yaml
+++ b/.github/workflows/gpd_get_fdr.yaml
@@ -1,7 +1,7 @@
 name: getGPDFdR
 on:
-  schedule:
-    - cron: '0 2 * * *'
+  # schedule:
+  #   - cron: '0 2 * * *'
     
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

- Disabled cron dispatch on `gpd_get_fdr.yaml` gha in order to stop the recovery of the FDR for GPD-Reporting

#### Motivation and Context

The job is no longer needed with the new version of the GPD-Reporting-Analysis.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
